### PR TITLE
fix: instead of error-ing, return single instance

### DIFF
--- a/src/app/broadcaster.service.spec.ts
+++ b/src/app/broadcaster.service.spec.ts
@@ -11,7 +11,6 @@ describe('Service: Broadcaster service', () => {
 
   afterEach( () => {
     broadcaster = null;
-    Broadcaster.refCount = 0;
   });
 
   it('Broadcaster can successfully send and receive messages', (done) => {
@@ -23,10 +22,13 @@ describe('Service: Broadcaster service', () => {
     broadcaster.broadcast('testEvent', 1001);
   });
 
-  it('Broadcaster can only be created once', () => {
-    expect(() => {
-      new Broadcaster();
-    }).toThrow();
+  it('Broadcaster can only be created once', (done) => {
+    broadcaster.on('cheese').subscribe((data: string) => {
+      expect(data).toEqual('cheddar');
+      done();
+    });
+
+    new Broadcaster().broadcast('cheese', 'cheddar');
   });
 });
 

--- a/src/app/broadcaster.service.ts
+++ b/src/app/broadcaster.service.ts
@@ -40,15 +40,11 @@ interface BroadcastEvent {
  */
 @Injectable()
 export class Broadcaster {
-  private _eventBus: Subject<BroadcastEvent>;
-  public static refCount: number = 0;
+  private _eventBus: Subject<BroadcastEvent> = new Subject<BroadcastEvent>();
+  private static instance: Broadcaster;
 
   constructor() {
-    this._eventBus = new Subject<BroadcastEvent>();
-    Broadcaster.refCount++;
-    if (Broadcaster.refCount > 1) {
-      throw new Error('Multiple broadcaster instances detected, this is a fatal error.');
-    }
+    return Broadcaster.instance = Broadcaster.instance || this;
   }
 
   /**
@@ -70,7 +66,7 @@ export class Broadcaster {
    */
   on<T>(key: any): Observable<T> {
     return this._eventBus.asObservable()
-      .filter(event => event.key === key)
-      .map(event => <T> event.data);
+      .filter((event: BroadcastEvent) => event.key === key)
+      .map((event: BroadcastEvent) => <T> event.data);
   }
 }

--- a/src/app/broadcaster.service.ts
+++ b/src/app/broadcaster.service.ts
@@ -38,13 +38,14 @@ interface BroadcastEvent {
  *     }
  *
  */
+let instance: Broadcaster;
+
 @Injectable()
 export class Broadcaster {
   private _eventBus: Subject<BroadcastEvent> = new Subject<BroadcastEvent>();
-  private static instance: Broadcaster;
 
   constructor() {
-    return Broadcaster.instance = Broadcaster.instance || this;
+    return instance = instance || this;
   }
 
   /**


### PR DESCRIPTION
Working with angular DI it's not always clear why a new instance of a service gets created especially if the same module is used across different modules ( as is the case for ngx-base ). Instead of throwing an error and counting the references it might be more handy for this class to be a singleton.